### PR TITLE
Force Commit

### DIFF
--- a/gh-license.py
+++ b/gh-license.py
@@ -9,7 +9,7 @@ from github import Github
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--scan", help="Scan repo of the user, arguments: [User_nick] [Report_file_name (optional)]", action="store_true")
-parser.add_argument("--license", help="Download a license file", action="store_true")
+parser.add_argument("--license", help="Download a license file, arguments: [License_name] [Git_remote_name (optional)]", action="store_true")
 parser.add_argument('args', nargs=argparse.REMAINDER)
 args = parser.parse_args()
 
@@ -79,6 +79,7 @@ if args.scan:
 elif args.license:
     if len(args.args) < 1:
          sys.stderr.write('  First parameter is missing: The license: GPLv2, GPLv3, LGPLv3, AGPLv3, FDLv1.3, Apachev2, CC-BY\n')
+         sys.stderr.write('  Second optional parameter: The license: git remote name (this would automatically push LICENSE to master)\n')
          sys.exit(1)
 
     if args.args[0] == 'GPLv2':
@@ -97,6 +98,10 @@ elif args.license:
         downloadLicense("http://creativecommons.org/licenses/by/3.0/legalcode.txt", args.args[0], '(https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)(http://creativecommons.org/licenses/by/4.0/)')
     else:
         print('License not found!')
+    if (len(args.args) > 1 and os.path.isdir(".git") and os.path.exists("LICENSE")):
+        os.system("git add LICENSE")
+        os.system("git commit -m 'missing license'")
+        os.system("git push " + args.args[1] + " master")
 else:
     print('  Remember without a license file your project is proprietary!')
     print('  GitHub License checker and downloader by Mte90')

--- a/gh-license.py
+++ b/gh-license.py
@@ -100,6 +100,10 @@ elif args.license:
         print('License not found!')
     if (len(args.args) > 1 and os.path.isdir(".git") and os.path.exists("LICENSE")):
         os.system("git add LICENSE")
+        readme_files = ['README.md','README.txt','readme','README','readme.txt','readme.md']
+        for readme_file in readme_files:
+            if os.path.isfile(readme_file):
+                os.system("git add "+readme_file)
         os.system("git commit -m 'missing license'")
         os.system("git push " + args.args[1] + " master")
 else:


### PR DESCRIPTION
User can optionally give the git remote name as 2nd argument to push the LICENSE on the provided remote repo.
Example: python3 gh-license.py --license GPLv2 origin
would push to origin
issue #4 
![push](https://cloud.githubusercontent.com/assets/16078071/18923086/b2ed32f6-85c8-11e6-9876-f34a72a88718.png)
