### PR TITLE
Fix requirements.txt missing error using MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
This will correctly include requirements.txt when packaging.

Additionally for uploading to PyPI I recommend reading through [Packaging & Distribution](https://packaging.python.org/distributing/) if you haven't already.