### PR TITLE
Detect current branch, print current_branch and operate on it

### DIFF
--- a/ghlicense/cmd.py
+++ b/ghlicense/cmd.py
@@ -31,13 +31,16 @@ ERR_PROVIDERS_TXT = "(errored providers: %s)" % ", ".join(
     DISABLED_PROVIDERS) if DISABLED_PROVIDERS else ""
 
 PARSER.add_argument(
-    "--scan", help="Scan repo of the user, arguments: [User_nick]", action="store")
+    "--scan", help="Scan repo of the user, arguments: [User_nick]", \
+    action="store")
 PARSER.add_argument(
-    "--license", help="Download a license file, arguments: [License_name]", nargs='?', const=True)
+    "--license", help="Download a license file, arguments: [License_name]", \
+    nargs='?', const=True)
 PARSER.add_argument(
     "--licenselist", help="Show licenses available", action="store_true")
 PARSER.add_argument("--provider",
-                    help="Repository provider. Defaults to github. Available providers: %s %s" %
+                    help="Repository provider. Defaults to github. \
+                    Available providers: %s %s" %
                     (", ".join(ENABLED_PROVIDERS), ERR_PROVIDERS_TXT),
                     action="store", default="github")
 PARSER.add_argument(
@@ -106,11 +109,12 @@ def update_license(url, name, badge):
             readme_file.close()
             print(f"Added badge license for {name} in {readme_name}.")
 
-            # If within a git repository, commit the above changes to current branch
+            # If within a git repo, commit the above changes to current branch
             # Verify which is the current branch
             try:
-                c_branch_bytes = os.popen("git rev-parse --abbrev-ref HEAD").read().encode("utf-8")
-                current_branch = c_branch_bytes.decode("utf-8").strip()
+                open_branch = os.popen("git rev-parse --abbrev-ref HEAD")
+                read_branch = open_branch.read().encode("utf-8")
+                current_branch = read_branch.decode("utf-8").strip()
                 print(f"Current Git branch is: {current_branch}")
             except Exception as e:
                 print(f"Error: {e}")

--- a/ghlicense/cmd.py
+++ b/ghlicense/cmd.py
@@ -325,8 +325,8 @@ def main():
                 if repo.fork:
                     print(' ! Is a fork, check the original or create a PR!')
                     report_file.write(' ! Is a fork, check the original or create a PR!\n')
-                    count_forked+=1
-            count_current+=1
+                    count_forked += 1
+            count_current += 1
             report_file.write("\n")
 
         # Update progress based on % of repos scanned

--- a/ghlicense/cmd.py
+++ b/ghlicense/cmd.py
@@ -107,15 +107,22 @@ def update_license(url, name, badge):
             print(f"Added badge license for {name} in {readme_name}.")
 
             # If within a git repository, commit the above changes to current branch
+            # Verify which is the current branch
+            try:
+                c_branch_bytes = os.popen("git rev-parse --abbrev-ref HEAD").read().encode("utf-8")
+                current_branch = c_branch_bytes.decode("utf-8").strip()
+                print(f"Current Git branch is: {current_branch}")
+            except Exception as e:
+                print(f"Error: {e}")
             if os.path.isdir('.git') and os.path.exists('LICENSE'):
                 os.system('git add LICENSE')
                 os.system(f"git add {readme_name}")
                 os.system(f"git commit -m 'Added {name} LICENSE'")
-                # If a remote repository exists attempt to push change to it
+                # If a remote repository exists, attempt to push changes to it
                 if ARGS.origin is not None:
-                    os.system(f"git push {ARGS.origin} master")
+                    os.system(f"git push {ARGS.origin} {current_branch}")
                 else:
-                    os.system('git push origin master')
+                    os.system(f"git push origin {current_branch}")
 
 
 def save_last_used_licenses(last_used_licenses):

--- a/ghlicense/cmd.py
+++ b/ghlicense/cmd.py
@@ -31,16 +31,13 @@ ERR_PROVIDERS_TXT = "(errored providers: %s)" % ", ".join(
     DISABLED_PROVIDERS) if DISABLED_PROVIDERS else ""
 
 PARSER.add_argument(
-    "--scan", help="Scan repo of the user, arguments: [User_nick]", \
-    action="store")
+    "--scan", help="Scan repo of the user, arguments: [User_nick]", action="store")
 PARSER.add_argument(
-    "--license", help="Download a license file, arguments: [License_name]", \
-    nargs='?', const=True)
+    "--license", help="Download a license file, arguments: [License_name]", nargs='?', const=True)
 PARSER.add_argument(
     "--licenselist", help="Show licenses available", action="store_true")
 PARSER.add_argument("--provider",
-                    help="Repository provider. Defaults to github. \
-                    Available providers: %s %s" %
+                    help="Repository provider. Defaults to github. Available providers: %s %s" %
                     (", ".join(ENABLED_PROVIDERS), ERR_PROVIDERS_TXT),
                     action="store", default="github")
 PARSER.add_argument(
@@ -109,12 +106,15 @@ def update_license(url, name, badge):
             readme_file.close()
             print(f"Added badge license for {name} in {readme_name}.")
 
-            # If within a git repo, commit the above changes to current branch
+            # If within a git repository, commit the above changes to current branch
             # Verify which is the current branch
             try:
-                open_branch = os.popen("git rev-parse --abbrev-ref HEAD")
-                read_branch = open_branch.read().encode("utf-8")
-                current_branch = read_branch.decode("utf-8").strip()
+                # os.popen() runs the command and capture its output as a file-like object \
+                # while read() will read the output of the command
+                current_branch_bytes = os.popen("git rev-parse --abbrev-ref HEAD").read().encode("utf-8")
+                # let's encode it and decode the UTF-8 bytes to a stringa \
+                # and strip whitespaces to get the branch name
+                current_branch = current_branch_bytes.decode("utf-8").strip()
                 print(f"Current Git branch is: {current_branch}")
             except Exception as e:
                 print(f"Error: {e}")
@@ -127,7 +127,6 @@ def update_license(url, name, badge):
                     os.system(f"git push {ARGS.origin} {current_branch}")
                 else:
                     os.system(f"git push origin {current_branch}")
-
 
 def save_last_used_licenses(last_used_licenses):
     """
@@ -399,7 +398,7 @@ def main():
         elif chosen_license == 'EUPL':
             update_license("https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt", chosen_license,
                            '(https://img.shields.io/badge/License-EUPL%20v1.1-blue.svg)](https://joinup.ec.europa.eu/page/eupl-guidelines-faq-infographics)')
-       else:
+        else:
             if isinstance(chosen_license, bool):
                 print('No license provided')
             else:
@@ -424,3 +423,6 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+
+

--- a/ghlicense/cmd.py
+++ b/ghlicense/cmd.py
@@ -388,8 +388,8 @@ def main():
         elif chosen_license == 'EUPL':
             update_license("https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt", chosen_license,
                            '(https://img.shields.io/badge/License-EUPL%20v1.1-blue.svg)](https://joinup.ec.europa.eu/page/eupl-guidelines-faq-infographics)')
-        else:
-            if isinstance(chosen_license) is bool:
+       else:
+            if isinstance(chosen_license, bool):
                 print('No license provided')
             else:
                 print(f"License {chosen_license} not found!")

--- a/ghlicense/cmd.py
+++ b/ghlicense/cmd.py
@@ -423,6 +423,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-
-


### PR DESCRIPTION
- According to the ticket 'Detect actual git branch before pushing', added current_branch variable.
Added capacity to detect the branch we are working in through OS module (already imported).
The variable 'current_branch' is printed, and then LICENSE and README.md are correctly pushed; no more errors if branch is not 'main' or 'master'.
- Fixed indentation errors I committed while editing cmd.py.
- Added missing whitespaces.
